### PR TITLE
Add seqAnnRegion methods along with some related changes to the record

### DIFF
--- a/src/main/resources/avro/methods.avdl
+++ b/src/main/resources/avro/methods.avdl
@@ -2,6 +2,35 @@
 
 protocol RPC {
 
+/** A query range suitable for inclusion in a positional range request. */
+record QueryRange {
+  /**
+  The identifier for the reference to query. Exactly one of `referenceId` and
+  `referenceName` should be specified.
+  */
+  union { null, string} referenceId;
+
+  /**
+  The name of the reference to query. Exactly one of `referenceId` and
+  `referenceName` should be specified.
+  */
+  union { null, string } referenceName;
+
+  /**
+  The start position (0-based) of this query. Defaults to 0.
+  Genomic positions are non-negative integers less than reference length.
+  Requests spanning the join of circular genomes are represented as
+  two requests one on each side of the join (position 0).
+  */
+  union { long, null } start = 0;
+
+  /**
+  The end position (0-based, exclusive) of this query. Defaults to the
+  reference's length.
+  */
+  union { null, long } end = null;
+}
+
 /**
 A general exception type.
 */
@@ -12,7 +41,5 @@ error GAException {
   /** The numerical error code */
   int errorCode = -1;
 }
-
-
 
 }

--- a/src/main/resources/avro/sequenceAnnotationmethods.avdl
+++ b/src/main/resources/avro/sequenceAnnotationmethods.avdl
@@ -1,0 +1,90 @@
+@namespace("org.ga4gh.methods")
+
+protocol SequenceAnnotationMethods {
+
+import idl "methods.avdl";
+import idl "sequenceAnnotations.avdl";
+
+/******************  /seqAnnRegions/search  *********************/
+
+/**
+This request maps to the body of `POST /seqAnnRegions/search` as JSON.
+*/
+record SearchSeqAnnRegionsRequest {
+  /**
+  The annotation sets to search within. Either `seqAnnRegionSetIds` or
+  `parentIds` must be non-empty.
+  */
+  array<string> seqAnnRegionSetIds = [];
+
+  /**
+  Restricts the search to direct children of the given parent `seqAnnRegion`
+  IDs. Either `seqAnnRegionSetIds` or `parentIds` must be non-empty.
+  */
+  array<string> parentIds = [];
+
+  /**
+  If specified, this query matches only annotations which overlap this range.
+  */
+  union { null, QueryRange } range = null;
+
+  /**
+  If specified, this query matches only annotations which match one of the
+  provided feature types.
+  */
+  array<org.ga4gh.models.OntologyTerm> features = [];
+
+  /**
+  Specifies the maximum number of results to return in a single page.
+  If unspecified, a system default will be used.
+  */
+  union { null, int } pageSize = null;
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  To get the next page of results, set this parameter to the value of
+  `nextPageToken` from the previous response.
+  */
+  union { null, string } pageToken = null;
+}
+
+/** This is the response from `POST /seqAnnRegions/search` expressed as JSON. */
+record SearchSeqAnnRegionsResponse {
+  /**
+  The list of matching annotations, sorted by start position. Annotations which
+  share a start position are returned in a deterministic order.
+  */
+  array<org.ga4gh.models.SeqAnnRegion> seqAnnRegions = [];
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  Provide this value in a subsequent request to return the next page of
+  results. This field will be empty if there aren't any additional results.
+  */
+  union { null, string } nextPageToken = null;
+}
+
+/**
+Gets a list of `SeqAnnRegion` matching the search criteria.
+
+`POST /seqAnnRegions/search` must accept a JSON version of
+`SearchSeqAnnRegionsRequest` as the post body and will return a JSON version of
+`SearchSeqAnnRegionsResponse`.
+*/
+SearchSeqAnnRegionsResponse searchSeqAnnRegions(
+  /** This request maps to the body of `POST /seqAnnRegions/search` as JSON. */
+  SearchSeqAnnRegionsRequest request) throws GAException;
+
+
+/****************  /seqAnnRegion/{id}  *******************/
+/**
+Gets a `org.ga4gh.models.SeqAnnRegion` by ID.
+`GET /seqAnnRegion/{id}` will return a JSON version of `SeqAnnRegion`.
+*/
+org.ga4gh.models.SeqAnnRegion getSeqAnnRegion(
+  /**
+  The ID of the `SeqAnnRegion`.
+  */
+  string id) throws GAException;
+
+}

--- a/src/main/resources/avro/sequenceAnnotations.avdl
+++ b/src/main/resources/avro/sequenceAnnotations.avdl
@@ -78,6 +78,11 @@ protocol SequenceAnnotations {
     union {null, string} id;
 
     /**
+    Identifier for the containing annotation set.
+    */
+    string annotationSetId;
+
+    /**
     Genomic location.
     */
     Region region;
@@ -86,7 +91,7 @@ protocol SequenceAnnotations {
     Feature that is annotated by this region.  Normally, this will be a term in
     the Sequence Ontology.
     */
-    OntologyTerm feature;
+    OntologyTerm feature; // TODO(calbach): Would prefer <something>Type.
 
     /**
     Name/value attributes of annotation.
@@ -98,9 +103,9 @@ protocol SequenceAnnotations {
     }> attributes;
 
     /**
-    Identifiers of children nodes
+    Identifier for the parent annotation, if any.
     */
-    array<string> childrenIds;
+    string parentId;
   }
 
   /*


### PR DESCRIPTION
Not a big fan of the naming currently, but that can be tackled across the board in a separate PR. The common `QueryRange` is idealistic and would probably be used in about 3-4 different places. Also changed to parentId over childrenIds as it makes the search by parentId query more natural.
